### PR TITLE
feat: 레디스를 활용한 쿠폰 발급 요청 처리 api 추가

### DIFF
--- a/coupon/coupon-api/src/main/java/com/project/couponapi/controller/CouponIssueController.java
+++ b/coupon/coupon-api/src/main/java/com/project/couponapi/controller/CouponIssueController.java
@@ -18,4 +18,10 @@ public class CouponIssueController {
         couponIssueRequestService.issueRequestV1(body);
         return new CouponIssueResponseDto(true, null);
     }
+
+    @PostMapping("/v1/issue-async")
+    public CouponIssueResponseDto asyncIssueV1(@RequestBody CouponIssueRequestDto body) {
+        couponIssueRequestService.asyncIssueRequestV1(body);
+        return new CouponIssueResponseDto(true, null);
+    }
 }

--- a/coupon/coupon-api/src/main/java/com/project/couponapi/service/CouponIssueRequestService.java
+++ b/coupon/coupon-api/src/main/java/com/project/couponapi/service/CouponIssueRequestService.java
@@ -2,6 +2,7 @@ package com.project.couponapi.service;
 
 import com.project.couponapi.controller.dto.CouponIssueRequestDto;
 import com.project.couponcore.component.DistributeLockExecutor;
+import com.project.couponcore.service.AsyncCouponIssueServiceV1;
 import com.project.couponcore.service.CouponIssueService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,11 +14,16 @@ import org.springframework.stereotype.Service;
 public class CouponIssueRequestService {
     private final CouponIssueService couponIssueService;
     private final DistributeLockExecutor distributeLockExecutor;
+    private final AsyncCouponIssueServiceV1 asyncCouponIssueServiceV1;
 
     public void issueRequestV1(CouponIssueRequestDto requestDto) {
         distributeLockExecutor.execute("lock_" + requestDto.couponId(), 10000, 10000, () -> {
             couponIssueService.issue(requestDto.couponId(), requestDto.userId());
         });
         log.info("쿠폰 발급 완료. couponId: %s, userId: %s".formatted(requestDto.couponId(), requestDto.userId()));
+    }
+
+    public void asyncIssueRequestV1(CouponIssueRequestDto requestDto) {
+        asyncCouponIssueServiceV1.issue(requestDto.couponId(), requestDto.userId());
     }
 }

--- a/coupon/coupon-core/src/main/java/com/project/couponcore/exception/ErrorCode.java
+++ b/coupon/coupon-core/src/main/java/com/project/couponcore/exception/ErrorCode.java
@@ -4,7 +4,8 @@ public enum ErrorCode {
     INVALID_COUPON_ISSUE_QUANTITY("쿠폰 발급 수량이 유효하지 않습니다."),
     INVALID_COUPON_ISSUE_DATE("쿠폰 발급 기간이 유효하지 않습니다."),
     COUPON_NOT_EXIST("존재하지 않는 쿠폰입니다."),
-    DUPLICATED_COUPON_ISSUE("이미 발급된 쿠폰입니다.");
+    DUPLICATED_COUPON_ISSUE("이미 발급된 쿠폰입니다."),
+    FAIL_COUPON_ISSUE_REQUEST("쿠폰 발급 요청에 실패했습니다.");
 
     public final String message;
 

--- a/coupon/coupon-core/src/main/java/com/project/couponcore/model/dto/request/RequestCouponIssueDto.java
+++ b/coupon/coupon-core/src/main/java/com/project/couponcore/model/dto/request/RequestCouponIssueDto.java
@@ -1,0 +1,4 @@
+package com.project.couponcore.model.dto.request;
+
+public record RequestCouponIssueDto(long couponId, long userId) {
+}

--- a/coupon/coupon-core/src/main/java/com/project/couponcore/repository/redis/RedisRepository.java
+++ b/coupon/coupon-core/src/main/java/com/project/couponcore/repository/redis/RedisRepository.java
@@ -24,4 +24,9 @@ public class RedisRepository {
     public Boolean sIsMember(String key, String value) {
         return redisTemplate.opsForSet().isMember(key, value);
     }
+
+    // 쿠폰 발급 큐에 적재하기 위한 리스트 자료구조 활용
+    public Long rPush(String key, String value) {
+        return redisTemplate.opsForList().rightPush(key, value);
+    }
 }

--- a/coupon/coupon-core/src/main/java/com/project/couponcore/service/AsyncCouponIssueServiceV1.java
+++ b/coupon/coupon-core/src/main/java/com/project/couponcore/service/AsyncCouponIssueServiceV1.java
@@ -1,0 +1,63 @@
+package com.project.couponcore.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.couponcore.component.DistributeLockExecutor;
+import com.project.couponcore.exception.CouponIssueException;
+import com.project.couponcore.model.Coupon;
+import com.project.couponcore.model.dto.request.RequestCouponIssueDto;
+import com.project.couponcore.repository.redis.RedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.project.couponcore.exception.ErrorCode.*;
+import static com.project.couponcore.util.CouponRedisUtils.getIssueRequestKey;
+import static com.project.couponcore.util.CouponRedisUtils.getIssueRequestQueueKey;
+
+@Service
+@RequiredArgsConstructor
+public class AsyncCouponIssueServiceV1 {
+    private final RedisRepository redisRepository;
+    private final CouponIssueRedisService couponIssueRedisService;
+    private final CouponIssueService couponIssueService;
+
+    private final DistributeLockExecutor distributeLockExecutor;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public void issue(long couponId, long userId) {
+        Coupon coupon = couponIssueService.findCoupon(couponId);
+        if (!coupon.availableIssueDate()) {
+            throw new CouponIssueException(INVALID_COUPON_ISSUE_DATE, "발급 가능한 일자가 아닙니다. couponId: %s, issueStart: %s, issueEnd: %s".formatted(couponId, coupon.getDateIssueStart(), coupon.getDateIssueEnd()));
+        }
+
+        // 레디스 동시성 이슈 해결하기 위함
+        distributeLockExecutor.execute("lock %s".formatted(couponId), 3000, 3000, () -> {
+            if (!couponIssueRedisService.availableTotalIssueQuantity(coupon.getTotalQuantity(), couponId)) {
+                throw new CouponIssueException(INVALID_COUPON_ISSUE_QUANTITY, "발급 가능한 수량을 초과합니다. couponId: %s, userId: %s".formatted(couponId, userId));
+            }
+
+            if (!couponIssueRedisService.availableUserIssueQuantity(couponId, userId)) {
+                throw new CouponIssueException(DUPLICATED_COUPON_ISSUE, "이미 발급 요청이 처리됐습니다. couponId: %s, userId: %s".formatted(couponId, userId));
+            }
+
+            issueRequest(couponId, userId);
+        });
+    }
+
+    /**
+     * 쿠폰 발급 요청 추가
+     */
+    private void issueRequest(long couponId, long userId) {
+        RequestCouponIssueDto requestCouponIssueDto = new RequestCouponIssueDto(couponId, userId);
+        // String 타입으로 직렬화
+        try {
+            String value = objectMapper.writeValueAsString(requestCouponIssueDto);
+
+            redisRepository.sAdd(getIssueRequestKey(couponId), String.valueOf(userId));
+            // 쿠폰 발급 큐에 적재
+            redisRepository.rPush(getIssueRequestQueueKey(), value);
+        } catch (JsonProcessingException e) {
+            throw new CouponIssueException(FAIL_COUPON_ISSUE_REQUEST, "input: %s".formatted(requestCouponIssueDto));
+        }
+    }
+}

--- a/coupon/coupon-core/src/main/java/com/project/couponcore/util/CouponRedisUtils.java
+++ b/coupon/coupon-core/src/main/java/com/project/couponcore/util/CouponRedisUtils.java
@@ -4,4 +4,8 @@ public class CouponRedisUtils {
     public static String getIssueRequestKey(long couponId) {
         return "issue.request.couponId=%s".formatted(couponId);
     }
+
+    public static String getIssueRequestQueueKey() {
+        return "issue.request";
+    }
 }

--- a/coupon/coupon-core/src/test/java/com/project/couponcore/service/AsyncCouponIssueServiceV1Test.java
+++ b/coupon/coupon-core/src/test/java/com/project/couponcore/service/AsyncCouponIssueServiceV1Test.java
@@ -1,0 +1,173 @@
+package com.project.couponcore.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.couponcore.TestConfig;
+import com.project.couponcore.exception.CouponIssueException;
+import com.project.couponcore.model.Coupon;
+import com.project.couponcore.model.CouponType;
+import com.project.couponcore.model.dto.request.RequestCouponIssueDto;
+import com.project.couponcore.repository.mysql.CouponJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.stream.IntStream;
+
+import static com.project.couponcore.exception.ErrorCode.*;
+import static com.project.couponcore.util.CouponRedisUtils.getIssueRequestKey;
+import static com.project.couponcore.util.CouponRedisUtils.getIssueRequestQueueKey;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AsyncCouponIssueServiceV1Test extends TestConfig {
+    @Autowired
+    AsyncCouponIssueServiceV1 sut;
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    CouponJpaRepository couponJpaRepository;
+
+    @BeforeEach
+    void clear() {
+        Collection<String> redisKeys = redisTemplate.keys("*");
+        redisTemplate.delete(redisKeys);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 - 쿠폰이 존재하지 않는다면 예외를 반환한다.")
+    void issue_1() {
+        // given
+        long couponId = 1;
+        long userId = 1;
+
+        // when & then
+        CouponIssueException exception = assertThrows(CouponIssueException.class, () -> {
+            sut.issue(couponId, userId);
+        });
+        assertEquals(exception.getErrorCode(), COUPON_NOT_EXIST);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 - 발급 가능 수량이 존재하지 않는다면 예외를 반환한다.")
+    void issue_2() {
+        // given
+        long userId = 100;
+        Coupon coupon = Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(10)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(1))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build();
+        couponJpaRepository.save(coupon);
+        IntStream.range(0, coupon.getTotalQuantity()).forEach(idx -> {
+           redisTemplate.opsForSet().add(getIssueRequestKey(coupon.getId()), String.valueOf(idx));
+        });
+
+        // when & then
+        CouponIssueException exception = assertThrows(CouponIssueException.class, () -> {
+            sut.issue(coupon.getId(), userId);
+        });
+        assertEquals(exception.getErrorCode(), INVALID_COUPON_ISSUE_QUANTITY);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 - 이미 발급된 유저라면 예외를 반환한다.")
+    void issue_3() {
+        // given
+        long userId = 1;
+        Coupon coupon = Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(10)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(1))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build();
+        couponJpaRepository.save(coupon);
+        redisTemplate.opsForSet().add(getIssueRequestKey(coupon.getId()), String.valueOf(userId));
+
+        // when & then
+        CouponIssueException exception = assertThrows(CouponIssueException.class, () -> {
+            sut.issue(coupon.getId(), userId);
+        });
+        assertEquals(exception.getErrorCode(), DUPLICATED_COUPON_ISSUE);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 - 발급 기한이 유효하지 않다면 예외를 반환한다.")
+    void issue_4() {
+        // given
+        long userId = 1;
+        Coupon coupon = Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(10)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().plusDays(1))
+                .dateIssueEnd(LocalDateTime.now().plusDays(2))
+                .build();
+        couponJpaRepository.save(coupon);
+        redisTemplate.opsForSet().add(getIssueRequestKey(coupon.getId()), String.valueOf(userId));
+
+        // when & then
+        CouponIssueException exception = assertThrows(CouponIssueException.class, () -> {
+            sut.issue(coupon.getId(), userId);
+        });
+        assertEquals(exception.getErrorCode(), INVALID_COUPON_ISSUE_DATE);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 - 쿠폰 발급을 레디스 set에 잘 기록하는지")
+    void issue_5() {
+        // given
+        long userId = 1;
+        Coupon coupon = Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(10)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(1))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build();
+        couponJpaRepository.save(coupon);
+
+        // when
+        sut.issue(coupon.getId(), userId);
+
+        // then
+        Boolean isSaved = redisTemplate.opsForSet().isMember(getIssueRequestKey(coupon.getId()), String.valueOf(userId));
+        assertTrue(isSaved);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 - 쿠폰 발급 요청이 성공하면, 쿠폰 발급 큐에 잘 적재되는지")
+    void issue_6() throws JsonProcessingException {
+        // given
+        long userId = 1;
+        Coupon coupon = Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(10)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(1))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build();
+        couponJpaRepository.save(coupon);
+        RequestCouponIssueDto requestCouponIssueDto = new RequestCouponIssueDto(coupon.getId(), userId);
+
+        // when
+        sut.issue(coupon.getId(), userId);
+
+        // then
+        String savedIssueRequest = redisTemplate.opsForList().leftPop(getIssueRequestQueueKey());
+        assertEquals(new ObjectMapper().writeValueAsString(requestCouponIssueDto), savedIssueRequest);
+    }
+}


### PR DESCRIPTION
Issue 번호
#6 


redis의 set을 활용한 구조
1. 유저 요청이 들어옴 (coupon_id, user_id)
2. 쿠폰 캐시를 통한 유효성 검증
    1. 쿠폰의 존재
    2. 쿠폰의 유효 기간
3. 중복 발급 요청 여부 확인 (SISMEMBER)
4. 수량 조회 (SCARD) 및 발급 가능 여부 검증
5. 요청 추가 (SADD)
6. 쿠폰 발급 Queue에 적재 (list 자료구조 활용)